### PR TITLE
Fixing some minor build specific issues 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.gradle/
+.idea/
+app/.cxx/
+build/
+jni/

--- a/app/src/main/jni/yolo.cpp
+++ b/app/src/main/jni/yolo.cpp
@@ -216,7 +216,7 @@ int Yolo::load(AAssetManager* mgr, const char* modeltype, int _target_size,  con
 #if NCNN_VULKAN
     yolo.opt.use_vulkan_compute = use_gpu;
 #endif
-    yolo.register_custom_layer("YoloV5Focus", YoloV5Focus_layer_creator);
+    //yolo.register_custom_layer("YoloV5Focus", YoloV5Focus_layer_creator);
     yolo.opt.num_threads = ncnn::get_big_cpu_count();
     yolo.opt.blob_allocator = &blob_pool_allocator;
     yolo.opt.workspace_allocator = &workspace_pool_allocator;


### PR DESCRIPTION
As the existing code-base is heavily borrowed from Yolox and Yolov5 implementations , the custom `YoloV5Focus` plugin is no longer needed, as there is no relevant functional implementation for the custom plugin, this causes compile time error while building the android project.